### PR TITLE
TRX quantity formatting

### DIFF
--- a/src/components/transfer/Send.js
+++ b/src/components/transfer/Send.js
@@ -204,7 +204,8 @@ class Send extends React.Component {
             <input type="number"
                    onChange={(ev) => this.setAmount(ev.target.value) }
                    className={"form-control " + (!isAmountValid ? "is-invalid" : "")}
-                   value={amount} />
+                   value={amount} 
+                   placeholder='0.0000'/>
             <div className="invalid-feedback">
               {tu("insufficient_tokens")}
             </div>


### PR DESCRIPTION
This is just a suggestion:
When sending TRX it is not clear if someone can send quantities with decimals or not. I'm pretty sure that only integer figures are allowed, but most of the people don't know.
Adding a placeholder with the right format in the form field could help users not get confused. 