### PR TITLE
Add Tooltip

### DIFF
--- a/src/components/blockchain/Blockchain.js
+++ b/src/components/blockchain/Blockchain.js
@@ -151,7 +151,7 @@ class Blockchain extends Component {
                 <i className="fas fa-cube fa-3x mr-3" style={{width: 50}}/>
                 <div className="lh-100">
                   <h6 className="mb-0 text-white lh-100">{tu("last_block")}</h6>
-                  <small>{blocks[0] && blocks[0].parentHash.substr(0, 16)}...</small>
+                  <small title={blocks[0] && blocks[0].parentHash}>{blocks[0] && blocks[0].parentHash.substr(0, 16)}...</small>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Adds a little tool-tip when hovering over the last block hash to display a non-trimmed version of it. Fixes #155 

![tooltip2](https://user-images.githubusercontent.com/33853949/39677565-1dca8db8-514b-11e8-921c-2bb370904528.png)